### PR TITLE
Fix fencepost error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ impl Model {
             .map(|(first, second)| second.duration_since(*first).as_micros())
             .sum();
 
-        let mean = sum_durations / self.beats.len() as u128;
+        let mean = sum_durations / (self.beats.len() - 1) as u128;
         Some(MINUTE_IN_MICROS / mean)
     }
 }


### PR DESCRIPTION
The BPM calculation is settling at one fifteenth higher than the true song BPM due to having one fewer interval than the number of beats recorded.

(I have not tested this change since I don't know what to do with a wasm binary)